### PR TITLE
Update check_vmware_ntp.pl

### DIFF
--- a/check_vmware_ntp.pl
+++ b/check_vmware_ntp.pl
@@ -84,9 +84,9 @@ my %opts = (
 );
 
 my $list;
-my $msg;
+my $msg = "";
 my $drift;
-my $ret;
+my $ret = 3;
 
 Opts::add_options(%opts);
 Opts::parse();
@@ -189,6 +189,11 @@ foreach my $host (@$hosts)
         print "$STATES{$ret}: $msg";
 }
 Util::disconnect();
+
+if(length $msg eq 0){
+    print "UNKNOWN - Error querying ESX server '".Opts::get_option('server')."'\n";
+}
+
 exit $ret;
 
 ## subs


### PR DESCRIPTION
Catches unavailable VMware API on ESX. Otherwise script returned "Use of uninitialized value $ret in exit at /usr/lib/nagios/plugins/check_vmware_ntp.pl line 192." and exited with return code zero when the VMware API was inaccessible.